### PR TITLE
Run the container privileged

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     image: decentralize/docker-plugin-volume-mounter
     cap_add:
       - SYS_ADMIN
+    privileged: true
     volumes:
       - /mnt/docker-volumes:/mnt/docker-volumes:shared
       - /var/lib/docker/plugins:/var/lib/docker/plugins:ro

--- a/start-container
+++ b/start-container
@@ -13,6 +13,7 @@ docker pull "$IMAGE"
 
 exec docker run -i --rm \
   --name docker-volume-mounter \
+  --privileged \
   --cap-add SYS_ADMIN \
   -v /var/lib/docker/plugins:/var/lib/docker/plugins:ro \
   -v /mnt/docker-volumes:/mnt/docker-volumes:shared \


### PR DESCRIPTION
There are "permission denied" errors with particular volume drivers otherwise (e.g. DigitalOcean).