### PR TITLE
Skip volumes with empty mountpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,10 +54,14 @@ func (mounter Mounter) MountCurrentVolumes() {
 
   for _, volume := range volumes.Volumes {
     if volume.Driver != "local" {
-			if _, err := os.Stat(volume.Mountpoint); os.IsNotExist(err) {
-			  fmt.Printf("Volume mountpoint %s does not exist, skipping volume %s\n", volume.Mountpoint, volume.Name)
-				continue
-			}
+      if volume.Mountpoint == "" {
+        fmt.Printf("Volume mountpoint is empty, skipping volume %s\n", volume.Name)
+        continue
+      }
+      if _, err := os.Stat(volume.Mountpoint); os.IsNotExist(err) {
+        fmt.Printf("Volume mountpoint %s does not exist, skipping volume %s\n", volume.Mountpoint, volume.Name)
+      	continue
+      }
 
       volume_path := mounter.getVolumePath(ctx, volume)
       fmt.Println("Checking for volume path " + volume_path)


### PR DESCRIPTION
This might occur for volumes which are not really mounted on the host (but e.g. on another swarm host).