### PR TITLE
fix: skip volumes with /rootfs mountpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func (mounter Mounter) MountCurrentVolumes() {
 
   for _, volume := range volumes.Volumes {
     if volume.Driver != "local" {
-      if volume.Mountpoint == "" {
+      if strings.HasSuffix(volume.Mountpoint, "/rootfs") {
         fmt.Printf("Volume mountpoint is empty, skipping volume %s\n", volume.Name)
         continue
       }


### PR DESCRIPTION
Changes the logic to skip volumes whose mountpoint ends with /rootfs instead of skipping volumes with empty mountpoints.

The "empty check" does not work.